### PR TITLE
Test enhancement about assertion equals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 7.2
+  - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -20,9 +20,9 @@ class EntityTest extends TestCase
         $entity = $this->makeEntity($attributes);
 
         $this->assertInstanceOf(Entity::class, $entity);
-        $this->assertEquals($attributes['name'], $entity->name);
-        $this->assertEquals($attributes['age'], $entity->age);
-        $this->assertEquals($attributes['job'], $entity->job);
+        $this->assertSame($attributes['name'], $entity->name);
+        $this->assertSame($attributes['age'], $entity->age);
+        $this->assertSame($attributes['job'], $entity->job);
         $this->assertNull($entity->country);
         $this->assertObjectNotHasAttribute('nickname', $entity);
         $this->assertTrue($entity->isConsistent());


### PR DESCRIPTION
# Changed log

- Add `php-7.3` and `php-7.4` versions during Travis CI build.
- Using the `assertSame` to replace `assertEquals` and makes assertion equals checking strict.